### PR TITLE
Add version to manifest

### DIFF
--- a/custom_components/harmony_ac/manifest.json
+++ b/custom_components/harmony_ac/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://github.com/so3n/HA_harmony_climate_component",
   "dependencies": [],
   "codeowners": [],
-  "requirements": []
+  "requirements": [],
+  "version": "0.2.0"
 }


### PR DESCRIPTION
Since Home Assistant 2021.3.0 the version is mandatory in the manifest:

```txt
Logger: homeassistant.loader
Source: loader.py:802
First occurred: 3 de marzo de 2021 21:58:47 (1 occurrences)
Last logged: 3 de marzo de 2021 21:58:47

No 'version' key in the manifest file for custom integration 'harmony_ac'. This will not be allowed in a future version of Home Assistant. Please report this to the maintainer of 'harmony_ac'
```